### PR TITLE
Add presto-cli to sandbox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV PRESTO_HOME=/opt/presto-server
 ARG PRESTO_VERSION
 ARG PRESTO_PKG=presto-server-${PRESTO_VERSION}.tar.gz
 ARG PRESTO_PKG_URL=https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/${PRESTO_PKG}
+ARG PRESTO_CLI=presto-cli-${PRESTO_VERSION}-executable.jar
+ARG PRESTO_CLI_URL=https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${PRESTO_VERSION}/${PRESTO_CLI}
 
 RUN apk add --no-cache \
     curl \
@@ -21,6 +23,8 @@ RUN apk add --no-cache \
   && mkdir -p ${PRESTO_HOME}/etc \
   && mkdir -p ${PRESTO_HOME}/etc/catalog \
   && mkdir -p /var/lib/presto/data \
+  && curl -o /opt/presto-cli ${PRESTO_CLI_URL} \
+  && chmod +x /opt/presto-cli \
   && ln -s /opt/presto-cli /usr/local/bin/presto-cli \
   && ln -s /opt/presto-cli /usr/local/bin/presto \
   && apk del curl tar


### PR DESCRIPTION
Thanks @MasterOdin for providing this replacement of the defunct `ahanaio/prestodb-sandbox`. I noticed the `presto-cli` seems to be missing from the Docker build.