### PR TITLE
Add accept header to manifest check

### DIFF
--- a/scripts/trigger_workflow.js
+++ b/scripts/trigger_workflow.js
@@ -54,6 +54,7 @@ const imageExists = async (version) => {
   const token = await getToken();
   const req = await fetch(`https://ghcr.io/v2/popsql/prestodb-sandbox/manifests/${version}`, {
     headers: {
+      Accept: 'application/vnd.oci.image.index.v1+json',
       Authorization: `Bearer ${token}`
     }
   });


### PR DESCRIPTION
PR fixes the check version script so that it will no longer error with:

```
{
  errors: [
    {
      code: 'MANIFEST_UNKNOWN',
      message: 'OCI index found, but Accept header does not support OCI indexes'
    }
  ]
}
```

and will instead return the manifest as expected (if it exists). This should mean that the `0.286` tag (and any future tag) is not redone every day.